### PR TITLE
Add more item manipulation options

### DIFF
--- a/dfpyre/items.py
+++ b/dfpyre/items.py
@@ -36,6 +36,27 @@ class item(NbtItem):
     """
     type = 'item'
 
+    def get_custom_tag(self, tag_name: str) -> str | float:
+        """
+        Get a custom DF tag value from this item.
+
+        :param str tag_name: The name of the custom tag to access.
+        """
+        if f'"hypercube:{tag_name}"' in self.nbt['tag']['PublicBukkitValues'].data:
+            return self.nbt['tag']['PublicBukkitValues'][f'"hypercube:{tag_name}"']
+        raise PyreException(f'Custom tag `{tag_name}` not found')
+
+    def set_custom_tag(self, tag_name: str, tag_value: str | float):
+        """
+        Set a custom DF tag for this item.
+
+        :param str tag_name: The name of the custom tag.
+        :param str tag_value: The value for the custom tag.
+        """
+        if isinstance(tag_value, int):
+            tag_value = float(tag_value)
+        self.nbt['tag']['PublicBukkitValues'][f'"hypercube:{tag_name}"'] = tag_value
+
     def format(self, slot: int|None):
         formatted_dict = {"item": {"id": self.type, "data": {"item": self.get_nbt()}}}
         _add_slot(formatted_dict, slot)

--- a/dfpyre/items.py
+++ b/dfpyre/items.py
@@ -51,7 +51,7 @@ class item(NbtItem):
         Set a custom DF tag for this item.
 
         :param str tag_name: The name of the custom tag.
-        :param str tag_value: The value for the custom tag.
+        :param str | float tag_value: The value for the custom tag.
         """
         if isinstance(tag_value, int):
             tag_value = float(tag_value)

--- a/dfpyre/items.py
+++ b/dfpyre/items.py
@@ -7,8 +7,7 @@ import re
 from typing import Literal, Any
 from dfpyre.style import is_ampersand_coded, ampersand_to_minimessage
 from dfpyre.util import PyreException, warn
-from mcitemlib.itemlib import Item as NbtItem
-
+from mcitemlib.itemlib import Item as NbtItem, AutoDict
 
 NUMBER_REGEX = r'-?\d*\.?\d+'
 VAR_SHORTHAND_CHAR = '$'
@@ -35,6 +34,21 @@ class item(NbtItem):
     Represents a Minecraft item.
     """
     type = 'item'
+
+    def glow(self):
+        """Apply the enchantment glow to this item."""
+        hide_flag_count = 0.0 if isinstance(self.nbt['tag']['HideFlags'], AutoDict) else self.get_tag('HideFlags')
+
+        self.set_tag('HideFlags', min(hide_flag_count + 1.0, 255.0))
+        self.set_enchantment('riptide' if 'fishing_rod' in self.get_id() else 'lure', 1)
+
+    def unbreakable(self):
+        """Make this item unbreakable."""
+        self.set_tag('Unbreakable', 1.0)
+
+    def hide_flags(self):
+        """Hide this item's flags."""
+        self.set_tag('HideFlags', 255.0)
 
     def get_custom_tag(self, tag_name: str) -> str | float:
         """


### PR DESCRIPTION
Is branched from #9, so if you choose to merge this, #9 should be merged first.

Add the glow, unbreakable, and hide_flags functions to the item class. They have functionally the same effect as the commands `/item glow`, `/item unbreakable`, and `/item hideflags`. The only major difference is that you can't undo glow like you can with `/item glow`